### PR TITLE
[feat] : 로그인 로직 보완 & 로그인 및 접근권한 체크용 ProtectedRoute 컴포넌트 구현

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -22,6 +22,7 @@
     "react/prop-types": "off",
     "react/jsx-props-no-spreading": "off",
     "react/button-has-type": "off",
+    "react/jsx-wrap-multilines": "off",
     "no-console": "off",
     "jsx-a11y/label-has-associated-control": [
       2,

--- a/src/App.js
+++ b/src/App.js
@@ -9,6 +9,7 @@ import PostWriteIntroPage from './pages/PostWriteIntroPage';
 import PostWritePage from './pages/PostWritePage';
 import ErrorPage from './pages/ErrorPage';
 import PostDetailWriterPage from './pages/PostDetailWriterPage';
+import ProtectedRoute from './components/templates/ProtectedRoute';
 import routes from './constant/routes';
 
 import './global.css';
@@ -20,7 +21,14 @@ function App() {
         <Route path={routes.home} element={<HomePage />} />
         <Route path={routes.login} element={<LoginPage />} />
         <Route path={routes.loginKakao} element={<KakaoOuathPage />} />
-        <Route path={routes.mypage} element={<MyPage />} />
+        <Route
+          path={routes.mypage}
+          element={
+            <ProtectedRoute>
+              <MyPage />
+            </ProtectedRoute>
+          }
+        />
         <Route path={routes.post} element={<PostListPage />} />
         <Route path={routes.detailPost} element={<PostDetailPage />} />
         <Route path={routes.postWriter} element={<PostDetailWriterPage />} />

--- a/src/components/templates/ProtectedRoute.jsx
+++ b/src/components/templates/ProtectedRoute.jsx
@@ -12,7 +12,7 @@ const ProtectedRoute = ({ children, requiredAuth }) => {
   // eslint-disable-next-line consistent-return
   const checkUserToken = () => {
     const userToken = localStorage.getItem('accessToken');
-    if (!userToken || userToken === 'undefined') {
+    if (!userToken) {
       setIsLoggedIn(false);
       Swal.fire(loginNeedMessage);
       navigate(routes.login);
@@ -23,20 +23,15 @@ const ProtectedRoute = ({ children, requiredAuth }) => {
   const checkUserAuth = () => {
     // requiredAuth(admin, student, user)가 존재할 경우, 현재 유저 권한에 대한 유효성을 검증
     // 사실상 user 권한의 경우는 로그인 토큰 자체만으로도 검증이 가능하기 때문에, 별도로 requiredAuth prop을 넘겨줄 필요 없음
-    if (requiredAuth) {
-      const userAuth = localStorage.getItem('userAuth');
-      // [admin, student] 이렇게 넘겨줄 수도 있는 경우를 감안하여 다음과 같이 처리
-      // requiredAuth 중 하나라도 만족하면, 페이지 접근 권한 유효함
-      if (requiredAuth.includes(userAuth)) {
-        setIsAuthValid(true);
-      } else {
-        setIsAuthValid(false);
-        Swal.fire(authInvalidMessage);
-        navigate(routes.mypage);
-      }
-    } else {
-      // requiredAuth(페이지별 접근 권한)가 제공되지 않았을 때는 항상 권한이 유효하다고 간주합니다.
+    // [admin, student] 이렇게 넘겨줄 수도 있는 경우를 감안하여 다음과 같이 처리
+    // requiredAuth 중 하나라도 만족하면, 페이지 접근 권한 유효함
+    const userAuth = localStorage.getItem('userAuth');
+    if (!requiredAuth || requiredAuth.includes(userAuth)) {
       setIsAuthValid(true);
+    } else {
+      setIsAuthValid(false);
+      Swal.fire(authInvalidMessage);
+      navigate(routes.mypage);
     }
   };
 

--- a/src/components/templates/ProtectedRoute.jsx
+++ b/src/components/templates/ProtectedRoute.jsx
@@ -1,0 +1,51 @@
+import React, { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import Swal from 'sweetalert2';
+import routes from '../../constant/routes';
+import { loginNeedMessage, authInvalidMessage } from '../../utils/alert';
+
+const ProtectedRoute = ({ children, requiredAuth }) => {
+  const navigate = useNavigate();
+  const [isLoggedIn, setIsLoggedIn] = useState(false);
+  const [isAuthVaild, setIsAuthValid] = useState(false);
+
+  // eslint-disable-next-line consistent-return
+  const checkUserToken = () => {
+    const userToken = localStorage.getItem('accessToken');
+    if (!userToken || userToken === 'undefined') {
+      setIsLoggedIn(false);
+      Swal.fire(loginNeedMessage);
+      navigate(routes.login);
+    }
+    setIsLoggedIn(true);
+  };
+
+  const checkUserAuth = () => {
+    // requiredAuth(admin, student, user)가 존재할 경우, 현재 유저 권한에 대한 유효성을 검증
+    // 사실상 user 권한의 경우는 로그인 토큰 자체만으로도 검증이 가능하기 때문에, 별도로 requiredAuth prop을 넘겨줄 필요 없음
+    if (requiredAuth) {
+      const userAuth = localStorage.getItem('grade');
+      // [admin, student] 이렇게 넘겨줄 수도 있는 경우를 감안하여 다음과 같이 처리
+      // requiredAuth 중 하나라도 만족하면, 페이지 접근 권한 유효함
+      if (requiredAuth.includes(userAuth)) {
+        setIsAuthValid(true);
+      } else {
+        setIsAuthValid(false);
+        Swal.fire(authInvalidMessage);
+        navigate(routes.mypage);
+      }
+    } else {
+      // requiredAuth(페이지별 접근 권한)가 제공되지 않았을 때는 항상 권한이 유효하다고 간주합니다.
+      setIsAuthValid(true);
+    }
+  };
+
+  useEffect(() => {
+    checkUserToken();
+    checkUserAuth();
+  }, [isLoggedIn, isAuthVaild]);
+
+  // eslint-disable-next-line react/jsx-no-useless-fragment, react/destructuring-assignment
+  return <>{isLoggedIn && isAuthVaild ? children : null}</>;
+};
+export default ProtectedRoute;

--- a/src/components/templates/ProtectedRoute.jsx
+++ b/src/components/templates/ProtectedRoute.jsx
@@ -24,7 +24,7 @@ const ProtectedRoute = ({ children, requiredAuth }) => {
     // requiredAuth(admin, student, user)가 존재할 경우, 현재 유저 권한에 대한 유효성을 검증
     // 사실상 user 권한의 경우는 로그인 토큰 자체만으로도 검증이 가능하기 때문에, 별도로 requiredAuth prop을 넘겨줄 필요 없음
     if (requiredAuth) {
-      const userAuth = localStorage.getItem('grade');
+      const userAuth = localStorage.getItem('userAuth');
       // [admin, student] 이렇게 넘겨줄 수도 있는 경우를 감안하여 다음과 같이 처리
       // requiredAuth 중 하나라도 만족하면, 페이지 접근 권한 유효함
       if (requiredAuth.includes(userAuth)) {

--- a/src/pages/KakaoOuathPage.jsx
+++ b/src/pages/KakaoOuathPage.jsx
@@ -21,6 +21,8 @@ const KakaoOuathPage = () => {
         try {
           console.log(kakaoOauthCode);
           localStorage.setItem('accessToken', 'token');
+          localStorage.setItem('grade', 'user');
+          localStorage.setItem('username', '김김김');
           Swal.fire(loginSuccessMessage).then(navigate(routes.home));
         } catch (error) {
           // console.log(error);

--- a/src/pages/KakaoOuathPage.jsx
+++ b/src/pages/KakaoOuathPage.jsx
@@ -21,7 +21,7 @@ const KakaoOuathPage = () => {
         try {
           console.log(kakaoOauthCode);
           localStorage.setItem('accessToken', 'token');
-          localStorage.setItem('grade', 'user');
+          localStorage.setItem('userAuth', 'user');
           localStorage.setItem('username', '김김김');
           Swal.fire(loginSuccessMessage).then(navigate(routes.home));
         } catch (error) {

--- a/src/pages/MyPage.jsx
+++ b/src/pages/MyPage.jsx
@@ -1,21 +1,7 @@
-import React, { useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
-import Swal from 'sweetalert2';
+import React from 'react';
 import MyPageTemplate from '../components/templates/MyPageTemplate';
-import { loginNeedMessage } from '../utils/alert';
-import routes from '../constant/routes';
 
 const MyPage = () => {
-  const navigate = useNavigate();
-
-  // 마이페이지 접속시 로그인 상태가 아니라면 로그인 페이지로 이동
-  useEffect(() => {
-    if (localStorage.getItem('accessToken') == null) {
-      Swal.fire(loginNeedMessage);
-      navigate(routes.login);
-    }
-  }, [navigate]);
-
   return <MyPageTemplate />;
 };
 

--- a/src/utils/alert.js
+++ b/src/utils/alert.js
@@ -12,3 +12,9 @@ export const loginNeedMessage = {
   text: '로그인을 먼저 해주세요😊',
   confirmButtonText: '확인',
 };
+export const authInvalidMessage = {
+  title: '해당 페이지에 대한 접근 권한이 없습니다!',
+  text: '접근 권한이 아예 없거나, 또는 학생증 인증을 진행해주세요!',
+  icon: 'error',
+  confirmButtonText: '확인',
+};


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] CSS등 UI 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 작업 사항

- 로그인 유무는 `localStorage`의 `accessToken`을 통해 확인
- 접근권한 체크는 `localStorage`의 `grade(→userAuth로 명칭 변경)`를 통해 확인
- 접근권한은 해당 컴포넌트로 감싼곳에서 `ProtectedRoute`에 `props`로 `requiredAuth` 값을 배열형태로 제공하면 적용
- 접근권한을 따로 제공하지 않으면 로그인 유무만 판단한다고 생각하면 됨
- **로그인 + 접근권한을 둘 다 체크**해야하는 곳에서는 `로그인(1순위) - 접근권한(2순위)`로 적용됨
- **로그인 x 인 경우**에는 로그인 경고 메시지와 함께 로그인페이지로 이동
- **접근권한 x 인 경우**에는 접근 거부 메시지와 함께 마이페이지로 이동(학생증 인증 권유)

> 동작 과정 설명

```
해당 예제에서는 마이페이지 & 공고 작성 입장 페이지에 임시로 ProtectedRoute를 적용시켰습니다.
마이페이지 - requiredAuth 값 x(이 경우에는 로그인 유무만 판단)
공고작성입장페이지 - requiredAuth 값이 배열 형태로 ['admin', 'student']가 주어짐
결론부터 말씀드리자면 특정 유저권한이있어야 접근 할 수 있도록 하기 위해서는 requiredAuth를 props로 전달해주세요!
```

![image](https://github.com/Step3-kakao-tech-campus/Team12_FE/assets/67001905/cb2c2be7-5b25-45fa-8c5d-a23a58b211c5)

![image](https://github.com/Step3-kakao-tech-campus/Team12_FE/assets/67001905/285542de-3317-4d45-87a3-8d3273617905)
→ 로그인 이후 `accessToken, userAuth, username`이 `localStorage`에 저장

![image](https://github.com/Step3-kakao-tech-campus/Team12_FE/assets/67001905/de6de14e-c32a-4e84-b48d-f6a737bbac90)
→ 위와 같은 과정을 통해 유저 권한에 따른 페이지 접근 처리 가능

![image](https://github.com/Step3-kakao-tech-campus/Team12_FE/assets/67001905/43e27686-7f15-410f-967f-128cf5bebd4b)
→ 로그인이 필요한 페이지

![image](https://github.com/Step3-kakao-tech-campus/Team12_FE/assets/67001905/562af6f5-a186-4519-aad0-fd2f30b79030)
→ 로그인 & 접근권한 둘 다 필요한 페이지(이경우, 로그인은 되었으나 현재 유저권한이 'user'여서 접근이 거부됨)

## 관련 이슈

- #10 
